### PR TITLE
Add AIChat.session() as context manager

### DIFF
--- a/simpleaichat/simpleaichat.py
+++ b/simpleaichat/simpleaichat.py
@@ -2,6 +2,7 @@ import os
 import datetime
 import dateutil
 from uuid import uuid4, UUID
+from contextlib import contextmanager
 import csv
 
 from pydantic import BaseModel
@@ -106,6 +107,15 @@ class AIChat(BaseModel):
                 self.default_session = None
         del self.sessions[sess.id]
         del sess
+
+    @contextmanager
+    def session(self, **kwargs):
+        sess = self.new_session(return_session=True, **kwargs)
+        self.sessions[sess.id] = sess
+        try:
+            yield sess
+        finally:
+            self.delete_session(sess.id)
 
     def __call__(
         self,


### PR DESCRIPTION
After seeing `ai.create_session()` and `ai.delete_session()` in your examples, I've thought it would be nice to have a context manager to create sessions.

```python
ai = AIChat(console=False)

with ai.session(...) as sess:
    print(sess.id)  # d374f2dc-7ffe-455c-add1-c7213cc86efe
    ai("hello!", id=sess.id)
    
with ai.session(...) as sess:
    print(sess.id)  # 341bf5e6-8330-44fa-91ce-9a07cc1e83fe
    ai("hello!", id=sess.id)
```