### PR TITLE
Support `AIChat.save_session(format="dict")` to receive the session's info in-memory

### DIFF
--- a/simpleaichat/simpleaichat.py
+++ b/simpleaichat/simpleaichat.py
@@ -234,6 +234,8 @@ class AIChat(BaseModel):
             exclude={"auth", "api_url", "input_fields"},
             exclude_none=True,
         )
+        if format == "dict":
+            return sess_dict
         out_path = f"test.{format}"
         if format == "csv":
             with open(out_path, "w", encoding="utf-8") as f:


### PR DESCRIPTION
Following [this](https://github.com/minimaxir/simpleaichat/issues/13#issuecomment-1595621634) question, although it is after sending to the API.