### PR TITLE
allow custom API URLs in ChatGPTSession

### DIFF
--- a/simpleaichat/chatgpt.py
+++ b/simpleaichat/chatgpt.py
@@ -99,7 +99,7 @@ class ChatGPTSession(ChatSession):
         )
 
         r = client.post(
-            self.api_url,
+            str(self.api_url),
             json=data,
             headers=headers,
             timeout=None,
@@ -145,7 +145,7 @@ class ChatGPTSession(ChatSession):
 
         with client.stream(
             "POST",
-            self.api_url,
+            str(self.api_url),
             json=data,
             headers=headers,
             timeout=None,
@@ -257,7 +257,7 @@ class ChatGPTSession(ChatSession):
         )
 
         r = await client.post(
-            self.api_url,
+            str(self.api_url),
             json=data,
             headers=headers,
             timeout=None,
@@ -303,7 +303,7 @@ class ChatGPTSession(ChatSession):
 
         async with client.stream(
             "POST",
-            self.api_url,
+            str(self.api_url),
             json=data,
             headers=headers,
             timeout=None,


### PR DESCRIPTION
This change allows a custom `api_url` to be used when creating a `ChatGPTSession`. 

Previously, if you instantiated AIChat with a custom `api_url` as a string, it resulted in an error when `httpx` attempted to send the request. For instance:
```python
ai = AIChat(api_key='None', api_url='http://localhost:8000/v1/chat/completions', console=False)
```
> Invalid type for url.  Expected str or httpx.URL, got <class 'pydantic_core._pydantic_core.Url'>: Url('http://localhost:8000/v1/chat/completions')

Now,  the `api_url` is cast to a string before it is used with `httpx`. This effectively removes the error and enables the use of a custom API URL. 

This can be useful in scenarios where requests need to be rerouted to a local server or a different API endpoint for development or testing purposes. A practical example of this is when using an open-source Language Model with an OpenAI-like API web server, such as the one provided by [llama.cpp](https://github.com/abetlen/llama-cpp-python#web-server).