### PR TITLE
feat: create a session when no api_key is passed with a custom URL

### DIFF
--- a/simpleaichat/chatgpt.py
+++ b/simpleaichat/chatgpt.py
@@ -31,7 +31,7 @@ class ChatGPTSession(ChatSession):
     ):
         headers = {
             "Content-Type": "application/json",
-            "Authorization": f"Bearer {self.auth['api_key'].get_secret_value()}",
+            "Authorization": f"Bearer {self.auth['api_key'].get_secret_value()}" if 'api_key' in self.auth else "",
         }
 
         system_message = ChatMessage(role="system", content=system or self.system)

--- a/simpleaichat/simpleaichat.py
+++ b/simpleaichat/simpleaichat.py
@@ -76,6 +76,11 @@ class AIChat(BaseModel):
                 },
                 **kwargs,
             )
+        else:
+            sess = ChatGPTSession(
+                **kwargs,
+                auth={}
+            )
 
         if return_session:
             return sess


### PR DESCRIPTION
Building on the work in #52, this PR allows creating a session with a ChatGPT compatible API without passing an api key.

This is the case when self-hosting llama-cpp sever or ChatGPT4All's API foir example.

Previously, the top-level API was not able to create a session for open source models using the openAI API:

```python
>>> ai = AIChat(api_key='None', api_url='http://localhost:8000/v1/chat/completions', console=False)
Traceback (most recent call last):
  File "C:\demo.py", line 10, in <module>
    ai = AIChat(
         ^^^^^^^
  File "c:\simpleaichat\simpleaichat.py", line 45, in __init__
    new_session = self.new_session(
                  ^^^^^^^^^^^^^^^^^
  File "c:\simpleaichat\simpleaichat.py", line 81, in new_session
    return sess
```

By the way I was surprised this didn't work when I tried and was wondering if you were thinking of adding tests to your library ?
I would love to help with that given enough time.