### PR TITLE
Add support for Azure, llama2, palm, claude2, cohere command nightly (etc)

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -24,6 +24,7 @@ setup(
         "python-dotenv>=1.0.0",
         "orjson>=3.9.0",
         "rich>=13.4.1",
+        "litellm>=0.1.400",
         "python-dateutil>=2.8.2",
     ],
 )

--- a/simpleaichat/chatgpt.py
+++ b/simpleaichat/chatgpt.py
@@ -5,6 +5,7 @@ import orjson
 
 from .models import ChatMessage, ChatSession
 from .utils import remove_a_key
+from litellm import completion
 
 tool_prompt = """From the list of tools below:
 - Reply ONLY with the number of the tool appropriate in response to the user's last message.
@@ -100,14 +101,12 @@ class ChatGPTSession(ChatSession):
             prompt, system, params, False, input_schema, output_schema
         )
 
-        r = client.post(
-            str(self.api_url),
-            json=data,
-            headers=headers,
-            timeout=None,
+        # API Keys can be set in .env or passed to litellm
+        # eg. if using .env set os.environ['OPENAI_API_KEY']
+        r = completion(
+            **data,
+            api_key=self.auth['api_key'].get_secret_value()
         )
-        r = r.json()
-
         try:
             if not output_schema:
                 content = r["choices"][0]["message"]["content"]


### PR DESCRIPTION
This PR adds support for models from all the above mentioned providers using https://github.com/BerriAI/litellm/

Here's a sample of how it's used:

```python
from litellm import completion, acompletion

## set ENV variables
# ENV variables can be set in .env file, too. Example in .env.example
os.environ["OPENAI_API_KEY"] = "openai key"
os.environ["COHERE_API_KEY"] = "cohere key"

messages = [{ "content": "Hello, how are you?","role": "user"}]

# openai call
response = completion(model="gpt-3.5-turbo", messages=messages)

# llama2 call
model_name = "replicate/llama-2-70b-chat:2c1608e18606fad2812020dc541930f2d0495ce32eee50074220b87300bc16e1"
response = completion(model_name, messages)

# cohere call
response = completion("command-nightly", messages)

# anthropic call
response = completion(model="claude-instant-1", messages=messages)
```
