### PR TITLE
Protect against input/output schema footgun when using tools

### DIFF
--- a/simpleaichat/simpleaichat.py
+++ b/simpleaichat/simpleaichat.py
@@ -125,6 +125,8 @@ class AIChat(BaseModel):
     ) -> str:
         sess = self.get_session(id)
         if tools:
+            assert (input_schema is None) and (output_schema is None), \
+                "When using tools, input/output schema are ignored"
             for tool in tools:
                 assert tool.__doc__, f"Tool {tool} does not have a docstring."
             assert len(tools) <= 9, "You can only have a maximum of 9 tools."
@@ -342,6 +344,8 @@ class AsyncAIChat(AIChat):
             self.client = AsyncClient(proxies=os.getenv("https_proxy"))
         sess = self.get_session(id)
         if tools:
+            assert (input_schema is None) and (output_schema is None), \
+                "When using tools, input/output schema are ignored"
             for tool in tools:
                 assert tool.__doc__, f"Tool {tool} does not have a docstring."
             assert len(tools) <= 9, "You can only have a maximum of 9 tools."


### PR DESCRIPTION
I was reading through the code and I saw that the input/output schema parameters are ignored when using tools. I added an assert statement to warn that the schemas are ignored when using tools.

I didn't test this, admittedly, but it's a small addition.

Thank you for creating this project! :)
