### PR TITLE
Fix access to deprecated __fields__ attribute

### DIFF
--- a/simpleaichat/chatgpt.py
+++ b/simpleaichat/chatgpt.py
@@ -75,7 +75,7 @@ class ChatGPTSession(ChatSession):
     def schema_to_function(self, schema: Any):
         assert schema.__doc__, f"{schema.__name__} is missing a docstring."
         assert (
-            "title" not in schema.__fields__.keys()
+            "title" not in schema.model_fields.keys()
         ), "`title` is a reserved keyword and cannot be used as a field name."
         schema_dict = schema.model_json_schema()
         remove_a_key(schema_dict, "title")


### PR DESCRIPTION
`__fields__` has been deprecated since v2 of Pydantic and is replaced by `model_fields`.